### PR TITLE
feat: improve `Cpf` debug output format

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,7 +103,7 @@ pub enum ParseCpfError {
 /// let cpf = "385.211.390-39".parse::<Cpf>().unwrap();
 /// assert!(cpf::valid(cpf));
 /// ```
-#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
+#[derive(PartialEq, Eq, Clone, Copy, Hash)]
 pub struct Cpf {
     digits: [u8; 11],
 }
@@ -219,6 +219,14 @@ fn parse<T: AsRef<str>>(cpf: T) -> Result<Cpf, ParseCpfError> {
 impl AsRef<str> for Cpf {
     fn as_ref(&self) -> &str {
         self.as_str()
+    }
+}
+
+impl fmt::Debug for Cpf {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("Cpf")
+            .field(&format_args!("{}", self))
+            .finish()
     }
 }
 


### PR DESCRIPTION
## Motivation

In a list containing several objects, the current approach seems overly intricate and notably unavailing, mainly due to the representation of values in ASCII instead of their true numerical forms, coupled with the requirement for a separate line for each digit. This aims to enhance readability.

## Example

Changes the debug representation from

```rust
Cpf {
    digits: [
        51,
        56,
        53,
        50,
        49,
        49,
        51,
        57,
        48,
        51,
        57,
    ],
}
```

to

```rust
Cpf(
    385.211.390-39,
)
```
